### PR TITLE
Anonymize Google Analytics IPs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -79,7 +79,8 @@
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-373800-1', 'dslab.epfl.ch');
+      ga('set', 'anonymizeIp', true);
+      ga('create', 'UA-373800-1', 'auto');
       ga('send', 'pageview');
     </script>
   </body>


### PR DESCRIPTION
According to EPFL rules:
http://atelierweb.epfl.ch/usage-google-analytics